### PR TITLE
Implement dynamic next page functionality.

### DIFF
--- a/pjscrape.js
+++ b/pjscrape.js
@@ -712,7 +712,7 @@ var pjs = (function(){
                 var s = this, opts = s.opts, url;
                 // check for load errors
                 url = page.evaluate(function () { return window.location + ""; });
-                }
+                
                 // look for 4xx or 5xx status codes
                 var statusCodeStart = String(page.resource.status).charAt(0);
                 if (statusCodeStart == '4' || statusCodeStart == '5') {

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -164,6 +164,10 @@ class TestPjscrape(unittest.TestCase):
         out = getPjscrapeOutput('test_persistent_state.js')
         self.assertEqual(out, '["Page 0","Page 1","Page 2"]')
         
+    def test_nextpage(self):
+        out = getPjscrapeOutput('test_nextpage.js')
+        self.assertEqual(out, '["Test Page: Next page","Test Page: Next page 2"]')
+
 if __name__ == '__main__':
     # run tests
     suite = unittest.TestLoader().loadTestsFromTestCase(TestPjscrape)

--- a/tests/test_nextpage.js
+++ b/tests/test_nextpage.js
@@ -1,0 +1,20 @@
+pjs.addSuite({
+    url: 'http://localhost:8888/test_site/nextpage.html',
+    scrapers: [
+        function() {
+            var items = $('h1').text();
+            return items;
+        }
+    ],
+    // maxDepth limits number of times the nextPage function will be evaluated
+    maxDepth: 1,
+    nextPage: function () {
+        var next = $('[alt="Next"]');
+        if (next.length) {
+            next.click();
+            return true;
+        } else {
+            return false;
+        }
+    }
+});

--- a/tests/test_site/nextpage.html
+++ b/tests/test_site/nextpage.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html> 
+  <head>
+    <title>TEST</title>
+  </head> 
+  <body>
+    <h1>Test Page: Next page</h1>
+    <form method="GET" action="nextpage2.html">
+    </form>
+    <a alt="Next" href="#" onclick="document.forms[0].submit();">Go to next page</a>
+    <script type="text/javascript" src="jquery-1.4.1.min.js"></script>
+  </body>
+</html>

--- a/tests/test_site/nextpage2.html
+++ b/tests/test_site/nextpage2.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html> 
+  <head>
+    <title>TEST</title>
+  </head> 
+  <body>
+    <h1>Test Page: Next page 2</h1>
+    <form method="GET" action="nextpage3.html">
+    </form>
+    <a alt="Next" href="#" onclick="document.forms[0].submit();">Go to next page</a>
+    <script type="text/javascript" src="jquery-1.4.1.min.js"></script>
+  </body>
+</html>

--- a/tests/test_site/nextpage3.html
+++ b/tests/test_site/nextpage3.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html> 
+  <head>
+    <title>TEST</title>
+  </head> 
+  <body>
+    <h1>Test Page: Next page 3</h1>
+    <script type="text/javascript" src="jquery-1.4.1.min.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
Sometimes a page has POST based navigation (yes, sadly this happens) and there isn't an URL where you could point pjscrape to go. In this case you need to start at a specific URL and navigate by issuing click events on certain DOM elements to get to the desired page. And this is something a scraping tool such as pjscrape, which runs in the browser, can really do well.

This pull request implements this functionality via two properties on pjs.suite. The "nextPage" is a function which determines and triggers an event, guiding browser to next page. It returns true when next page was requested and false otherwise. The other property is "maxDepth" which determines how many times can next page be requested (useful for example for scraping POST based pagination, but no more than N pages). Included test demonstrates the functionality.
